### PR TITLE
Extend observation window to 1 year

### DIFF
--- a/R/dataset.R
+++ b/R/dataset.R
@@ -39,7 +39,7 @@ tableOptions   <- function(id) {
 
         dateRangeInput(
             NS(id, "range"), "Dates of interest:",
-            start = Sys.Date() - months(6), end = Sys.Date(),
+            start = Sys.Date() - months(12), end = Sys.Date(), # changed to 12 months
             max =  Sys.Date()
         )
 

--- a/R/main.R
+++ b/R/main.R
@@ -21,7 +21,7 @@ run_odyssey <- function(...) {
 
         title = tagList(
             h3(
-                "Exploring Molecular Biodiversity in Greece",
+                "Exploring Molecular Biodiversity",
                 style = "color: #F3F6FA; margin-bottom: 1px; margin-top: 1px;
                   white-space: nowrap;"
             ),


### PR DESCRIPTION
Resolves #12 

Updates the time window for displaying observations from the past 6 months to the past 1 year.

The previous 6-month window led to no available observations for early 2025, which caused the app to return empty results or errors on load.