### PR TITLE
Add github action resqui

### DIFF
--- a/.github/workflows/resqui.yaml
+++ b/.github/workflows/resqui.yaml
@@ -1,0 +1,23 @@
+name: Run resqui
+
+on:
+  push:
+
+jobs:
+  run-resqui:
+    runs-on: ubuntu-latest
+    environment: resqui
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run resqui action
+        uses: EVERSE-ResearchSoftware/QualityPipelines@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          config: resqui.json
+      - name: Show output
+        run: cat resqui_summary.json

--- a/resqui.json
+++ b/resqui.json
@@ -1,0 +1,14 @@
+{
+  "indicators": [
+    {
+      "name": "has_license",
+      "plugin": "HowFairIs",
+      "@id": "https://w3id.org/everse/i/indicators/license"
+    },
+    {
+      "name": "has_citation",
+      "plugin": "CFFConvert",
+      "@id": "https://w3id.org/everse/i/indicators/citation"
+    }
+  ]
+}


### PR DESCRIPTION
Hi!

I have attempted to add a github action integrating minimally resqui. A command line tool for research software quality assurance (https://github.com/EVERSE-ResearchSoftware/QualityPipelines).

Based on the docs, we could also publish the output of the quality checks on a https://github.com/EVERSE-ResearchSoftware/DashVERSE instance. Specifically,
> Add a secret named DASHVERSE_TOKEN to that environment (obtain it from your DashVerse instance). If you do not have a DashVerse token the step will report a failure but the assessment itself still runs.
source: https://everse.software/QualityPipelines/how-to/ci-integration/

I am not sure if we should have a local DashVERSE instance or are we supposed to use the public one https://www.dashverse.cloud/, which seems to be under development as well, and how exactly the token can be generated.

Currently, I have just added a very minimal simple `cat` of the output file (`resqui_summary.json`), to validate that the checks have been performed.

Additionally, based on the output each check has an "output" field that is either "valid" or "invalid". We can use jq to inspect that and exit with a non-zero code if any check failed.

You can check the run on my fork here https://github.com/thodkatz/ELIXIR-BFSP-Odyssey/actions/runs/24453524802/job/71448123377.